### PR TITLE
Add shared list formatting infrastructure for CLI commands

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -122,6 +122,13 @@ let package = Package(
                 "ContainerBuild"
             ]
         ),
+        .testTarget(
+            name: "ContainerCommandsTests",
+            dependencies: [
+                "ContainerCommands",
+                "ContainerResource",
+            ]
+        ),
         .executableTarget(
             name: "container-apiserver",
             dependencies: [

--- a/Sources/ContainerCommands/Application.swift
+++ b/Sources/ContainerCommands/Application.swift
@@ -245,11 +245,6 @@ extension Application {
         print(altered)
     }
 
-    public enum ListFormat: String, CaseIterable, ExpressibleByArgument {
-        case json
-        case table
-    }
-
     func isTranslated() throws -> Bool {
         do {
             return try Sysctl.byName("sysctl.proc_translated") == 1

--- a/Sources/ContainerCommands/Builder/BuilderStatus.swift
+++ b/Sources/ContainerCommands/Builder/BuilderStatus.swift
@@ -45,60 +45,53 @@ extension Application {
             do {
                 let client = ContainerClient()
                 let container = try await client.get(id: "buildkit")
-                try printContainers(containers: [container], format: format)
+
+                if format == .json {
+                    try printJSON([PrintableContainer(container)])
+                    return
+                }
+
+                if quiet && container.status != .running {
+                    return
+                }
+
+                printList([PrintableBuilder(container)], quiet: quiet)
             } catch {
-                if error is ContainerizationError {
-                    if (error as? ContainerizationError)?.code == .notFound && !quiet {
+                if let czError = error as? ContainerizationError, czError.code == .notFound {
+                    if !quiet {
                         print("builder is not running")
-                        return
                     }
+                    return
                 }
                 throw error
             }
         }
-
-        private func createHeader() -> [[String]] {
-            [["ID", "IMAGE", "STATE", "ADDR", "CPUS", "MEMORY"]]
-        }
-
-        private func printContainers(containers: [ContainerSnapshot], format: ListFormat) throws {
-            if format == .json {
-                let printables = containers.map {
-                    PrintableContainer($0)
-                }
-                let data = try JSONEncoder().encode(printables)
-                print(String(decoding: data, as: UTF8.self))
-
-                return
-            }
-
-            if self.quiet {
-                containers
-                    .filter { $0.status == .running }
-                    .forEach { print($0.id) }
-                return
-            }
-
-            var rows = createHeader()
-            for container in containers {
-                rows.append(container.asRow)
-            }
-
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
-        }
     }
 }
 
-extension ContainerSnapshot {
-    fileprivate var asRow: [String] {
+private struct PrintableBuilder: ListDisplayable {
+    let snapshot: ContainerSnapshot
+
+    init(_ snapshot: ContainerSnapshot) {
+        self.snapshot = snapshot
+    }
+
+    static var tableHeader: [String] {
+        ["ID", "IMAGE", "STATE", "ADDR", "CPUS", "MEMORY"]
+    }
+
+    var tableRow: [String] {
         [
-            self.id,
-            self.configuration.image.reference,
-            self.status.rawValue,
-            self.networks.compactMap { $0.ipv4Address.description }.joined(separator: ","),
-            "\(self.configuration.resources.cpus)",
-            "\(self.configuration.resources.memoryInBytes / (1024 * 1024)) MB",
+            snapshot.id,
+            snapshot.configuration.image.reference,
+            snapshot.status.rawValue,
+            snapshot.networks.map { $0.ipv4Address.description }.joined(separator: ","),
+            "\(snapshot.configuration.resources.cpus)",
+            "\(snapshot.configuration.resources.memoryInBytes / (1024 * 1024)) MB",
         ]
+    }
+
+    var quietValue: String {
+        snapshot.id
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerInspect.swift
+++ b/Sources/ContainerCommands/Container/ContainerInspect.swift
@@ -36,12 +36,12 @@ extension Application {
 
         public func run() async throws {
             let client = ContainerClient()
-            let objects: [any Codable] = try await client.list().filter {
+            let containers = try await client.list().filter {
                 containerIds.contains($0.id)
             }.map {
                 PrintableContainer($0)
             }
-            print(try objects.jsonArray())
+            try printJSON(containers)
         }
     }
 }

--- a/Sources/ContainerCommands/Container/ContainerList.swift
+++ b/Sources/ContainerCommands/Container/ContainerList.swift
@@ -46,59 +46,43 @@ extension Application {
             let client = ContainerClient()
             let filters = self.all ? ContainerListFilters.all : ContainerListFilters(status: .running)
             let containers = try await client.list(filters: filters)
-            try printContainers(containers: containers, format: format)
-        }
+            let items = containers.map { PrintableContainer($0) }
 
-        private func createHeader() -> [[String]] {
-            [["ID", "IMAGE", "OS", "ARCH", "STATE", "ADDR", "CPUS", "MEMORY", "STARTED"]]
-        }
-
-        private func printContainers(containers: [ContainerSnapshot], format: ListFormat) throws {
             if format == .json {
-                let printables = containers.map {
-                    PrintableContainer($0)
-                }
-                let data = try JSONEncoder().encode(printables)
-                print(String(decoding: data, as: UTF8.self))
-
+                try printJSON(items)
                 return
             }
 
-            if self.quiet {
-                containers.forEach {
-                    print($0.id)
-                }
-                return
-            }
-
-            var rows = createHeader()
-            for container in containers {
-                rows.append(container.asRow)
-            }
-
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
+            printList(items, quiet: quiet)
         }
     }
 }
 
-extension ContainerSnapshot {
-    fileprivate var asRow: [String] {
+extension PrintableContainer: ListDisplayable {
+    static var tableHeader: [String] {
+        ["ID", "IMAGE", "OS", "ARCH", "STATE", "ADDR", "CPUS", "MEMORY", "STARTED"]
+    }
+
+    var tableRow: [String] {
         [
-            self.id,
+            self.configuration.id,
             self.configuration.image.reference,
-            self.platform.os,
-            self.platform.architecture,
+            self.configuration.platform.os,
+            self.configuration.platform.architecture,
             self.status.rawValue,
-            self.networks.compactMap { $0.ipv4Address.description }.joined(separator: ","),
+            self.networks.map { $0.ipv4Address.description }.joined(separator: ","),
             "\(self.configuration.resources.cpus)",
             "\(self.configuration.resources.memoryInBytes / (1024 * 1024)) MB",
-            self.startedDate.map { ISO8601DateFormatter().string(from: $0) } ?? "",
+            self.startedDate?.ISO8601Format() ?? "",
         ]
+    }
+
+    var quietValue: String {
+        self.configuration.id
     }
 }
 
-struct PrintableContainer: Codable {
+struct PrintableContainer: Codable, Sendable {
     let status: RuntimeStatus
     let configuration: ContainerConfiguration
     let networks: [Attachment]

--- a/Sources/ContainerCommands/Container/ContainerStats.swift
+++ b/Sources/ContainerCommands/Container/ContainerStats.swift
@@ -104,8 +104,7 @@ extension Application {
 
             if format == .json {
                 let jsonStats = statsData.map { $0.stats2 }
-                let data = try JSONEncoder().encode(jsonStats)
-                print(String(decoding: data, as: UTF8.self))
+                try printJSON(jsonStats)
                 return
             }
 

--- a/Sources/ContainerCommands/Image/ImageInspect.swift
+++ b/Sources/ContainerCommands/Image/ImageInspect.swift
@@ -17,6 +17,7 @@
 import ArgumentParser
 import ContainerAPIClient
 import ContainerLog
+import ContainerResource
 import ContainerizationError
 import Foundation
 import Logging
@@ -42,7 +43,7 @@ extension Application {
         }
 
         public func run() async throws {
-            var printable = [any Codable]()
+            var printable: [ImageDetail] = []
             var succeededImages: [String] = []
             var allErrors: [(String, Error)] = []
 
@@ -59,7 +60,7 @@ extension Application {
             }
 
             if !printable.isEmpty {
-                print(try printable.jsonArray())
+                try printJSON(printable)
             }
 
             if !allErrors.isEmpty {

--- a/Sources/ContainerCommands/Image/ImageList.swift
+++ b/Sources/ContainerCommands/Image/ImageList.swift
@@ -23,7 +23,13 @@ import Foundation
 import SwiftProtobuf
 
 extension Application {
-    public struct ListImageOptions: ParsableArguments {
+    public struct ImageList: AsyncLoggableCommand {
+        public init() {}
+        public static let configuration = CommandConfiguration(
+            commandName: "list",
+            abstract: "List images",
+            aliases: ["ls"])
+
         @Option(name: .long, help: "Format of the output")
         var format: ListFormat = .table
 
@@ -33,26 +39,87 @@ extension Application {
         @Flag(name: .shortAndLong, help: "Verbose output")
         var verbose = false
 
-        public init() {}
-    }
+        @OptionGroup
+        public var logOptions: Flags.Logging
 
-    struct ListImageImplementation {
-        static func createHeader() -> [[String]] {
-            [["NAME", "TAG", "DIGEST"]]
+        public mutating func run() async throws {
+            try Self.validate(format: format, quiet: quiet, verbose: verbose)
+
+            var images = try await ClientImage.list().filter { img in
+                !Utility.isInfraImage(name: img.reference)
+            }
+            images.sort { $0.reference < $1.reference }
+
+            if format == .json {
+                try await Self.emitJSON(images: images)
+                return
+            }
+
+            if quiet {
+                for image in images {
+                    let processedReferenceString = try ClientImage.denormalizeReference(image.reference)
+                    print(processedReferenceString)
+                }
+                return
+            }
+
+            if verbose {
+                let items = try await Self.buildVerboseItems(images: images)
+                printList(items, quiet: false)
+                return
+            }
+
+            let items = try await Self.buildTableItems(images: images)
+            printList(items, quiet: false)
         }
 
-        static func createVerboseHeader() -> [[String]] {
-            [["NAME", "TAG", "INDEX DIGEST", "OS", "ARCH", "VARIANT", "FULL SIZE", "CREATED", "MANIFEST DIGEST"]]
+        private static func validate(format: ListFormat, quiet: Bool, verbose: Bool) throws {
+            if quiet && verbose {
+                throw ContainerizationError(.invalidArgument, message: "cannot use flag --quiet and --verbose together")
+            }
+            let modifier = quiet || verbose
+            if modifier && format == .json {
+                throw ContainerizationError(.invalidArgument, message: "cannot use flag --quiet or --verbose along with --format json")
+            }
         }
 
-        static func printImagesVerbose(images: [ClientImage]) async throws {
-
-            var rows = createVerboseHeader()
+        private static func emitJSON(images: [ClientImage]) async throws {
+            let formatter = ByteCountFormatter()
+            var printableImages: [PrintableImage] = []
             for image in images {
-                let formatter = ByteCountFormatter()
+                let size = try await ClientImage.getFullImageSize(image: image)
+                let formattedSize = formatter.string(fromByteCount: size)
+                printableImages.append(
+                    PrintableImage(reference: image.reference, fullSize: formattedSize, descriptor: image.descriptor)
+                )
+            }
+            try printJSON(printableImages)
+        }
+
+        private static func buildTableItems(images: [ClientImage]) async throws -> [ImageRow] {
+            var items: [ImageRow] = []
+            for image in images {
+                let processedReferenceString = try ClientImage.denormalizeReference(image.reference)
+                let reference = try ContainerizationOCI.Reference.parse(processedReferenceString)
+                let digest = try await image.resolved().digest
+                items.append(
+                    ImageRow(
+                        name: reference.name,
+                        tag: reference.tag ?? "<none>",
+                        trimmedDigest: Utility.trimDigest(digest: digest)
+                    ))
+            }
+            return items
+        }
+
+        private static func buildVerboseItems(images: [ClientImage]) async throws -> [VerboseImageRow] {
+            let formatter = ByteCountFormatter()
+            var items: [VerboseImageRow] = []
+            for image in images {
                 let imageDigest = try await image.resolved().digest
+                let processedReferenceString = try ClientImage.denormalizeReference(image.reference)
+                let reference = try ContainerizationOCI.Reference.parse(processedReferenceString)
                 for descriptor in try await image.index().manifests {
-                    // Don't list attestation manifests
                     if let referenceType = descriptor.annotations?["vnd.docker.reference.type"],
                         referenceType == "attestation-manifest"
                     {
@@ -62,10 +129,6 @@ extension Application {
                     guard let platform = descriptor.platform else {
                         continue
                     }
-
-                    let os = platform.os
-                    let arch = platform.architecture
-                    let variant = platform.variant ?? ""
 
                     var config: ContainerizationOCI.Image
                     var manifest: ContainerizationOCI.Manifest
@@ -77,126 +140,74 @@ extension Application {
                     }
 
                     let created = config.created ?? ""
-                    let size = descriptor.size + manifest.config.size + manifest.layers.reduce(0, { (l, r) in l + r.size })
+                    let size = descriptor.size + manifest.config.size + manifest.layers.reduce(0) { $0 + $1.size }
                     let formattedSize = formatter.string(fromByteCount: size)
 
-                    let processedReferenceString = try ClientImage.denormalizeReference(image.reference)
-                    let reference = try ContainerizationOCI.Reference.parse(processedReferenceString)
-                    let row = [
-                        reference.name,
-                        reference.tag ?? "<none>",
-                        Utility.trimDigest(digest: imageDigest),
-                        os,
-                        arch,
-                        variant,
-                        formattedSize,
-                        created,
-                        Utility.trimDigest(digest: descriptor.digest),
-                    ]
-                    rows.append(row)
+                    items.append(
+                        VerboseImageRow(
+                            name: reference.name,
+                            tag: reference.tag ?? "<none>",
+                            indexDigest: Utility.trimDigest(digest: imageDigest),
+                            os: platform.os,
+                            arch: platform.architecture,
+                            variant: platform.variant ?? "",
+                            fullSize: formattedSize,
+                            created: created,
+                            manifestDigest: Utility.trimDigest(digest: descriptor.digest)
+                        ))
                 }
             }
-
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
-        }
-
-        static func printImages(images: [ClientImage], format: ListFormat, options: ListImageOptions) async throws {
-            var images = images
-            images.sort {
-                $0.reference < $1.reference
-            }
-
-            if format == .json {
-                var printableImages: [PrintableImage] = []
-                for image in images {
-                    let formatter = ByteCountFormatter()
-                    let size = try await ClientImage.getFullImageSize(image: image)
-                    let formattedSize = formatter.string(fromByteCount: size)
-
-                    printableImages.append(
-                        PrintableImage(reference: image.reference, fullSize: formattedSize, descriptor: image.descriptor)
-                    )
-                }
-                let data = try JSONEncoder().encode(printableImages)
-                print(String(decoding: data, as: UTF8.self))
-                return
-            }
-
-            if options.quiet {
-                try images.forEach { image in
-                    let processedReferenceString = try ClientImage.denormalizeReference(image.reference)
-                    print(processedReferenceString)
-                }
-                return
-            }
-
-            if options.verbose {
-                try await Self.printImagesVerbose(images: images)
-                return
-            }
-
-            var rows = createHeader()
-            for image in images {
-                let processedReferenceString = try ClientImage.denormalizeReference(image.reference)
-                let reference = try ContainerizationOCI.Reference.parse(processedReferenceString)
-                let digest = try await image.resolved().digest
-                rows.append([
-                    reference.name,
-                    reference.tag ?? "<none>",
-                    Utility.trimDigest(digest: digest),
-                ])
-            }
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
-        }
-
-        static func validate(options: ListImageOptions) throws {
-            if options.quiet && options.verbose {
-                throw ContainerizationError(.invalidArgument, message: "cannot use flag --quiet and --verbose together")
-            }
-            let modifier = options.quiet || options.verbose
-            if modifier && options.format == .json {
-                throw ContainerizationError(.invalidArgument, message: "cannot use flag --quiet or --verbose along with --format json")
-            }
-        }
-
-        static func listImages(options: ListImageOptions) async throws {
-            let images = try await ClientImage.list().filter { img in
-                !Utility.isInfraImage(name: img.reference)
-            }
-            try await printImages(images: images, format: options.format, options: options)
+            return items
         }
 
         struct PrintableImage: Codable {
             let reference: String
             let fullSize: String
             let descriptor: Descriptor
-
-            init(reference: String, fullSize: String, descriptor: Descriptor) {
-                self.reference = reference
-                self.fullSize = fullSize
-                self.descriptor = descriptor
-            }
         }
     }
+}
 
-    public struct ImageList: AsyncLoggableCommand {
-        public init() {}
-        public static let configuration = CommandConfiguration(
-            commandName: "list",
-            abstract: "List images",
-            aliases: ["ls"])
+private struct ImageRow: ListDisplayable {
+    let name: String
+    let tag: String
+    let trimmedDigest: String
 
-        @OptionGroup
-        var options: ListImageOptions
+    static var tableHeader: [String] {
+        ["NAME", "TAG", "DIGEST"]
+    }
 
-        @OptionGroup
-        public var logOptions: Flags.Logging
+    var tableRow: [String] {
+        [name, tag, trimmedDigest]
+    }
 
-        public mutating func run() async throws {
-            try ListImageImplementation.validate(options: options)
-            try await ListImageImplementation.listImages(options: options)
-        }
+    // Required by ListDisplayable but unused — ImageList handles quiet mode
+    // separately to avoid expensive digest resolution.
+    var quietValue: String {
+        name
+    }
+}
+
+private struct VerboseImageRow: ListDisplayable {
+    let name: String
+    let tag: String
+    let indexDigest: String
+    let os: String
+    let arch: String
+    let variant: String
+    let fullSize: String
+    let created: String
+    let manifestDigest: String
+
+    static var tableHeader: [String] {
+        ["NAME", "TAG", "INDEX DIGEST", "OS", "ARCH", "VARIANT", "FULL SIZE", "CREATED", "MANIFEST DIGEST"]
+    }
+
+    var tableRow: [String] {
+        [name, tag, indexDigest, os, arch, variant, fullSize, created, manifestDigest]
+    }
+
+    var quietValue: String {
+        name
     }
 }

--- a/Sources/ContainerCommands/ListDisplayable.swift
+++ b/Sources/ContainerCommands/ListDisplayable.swift
@@ -1,5 +1,5 @@
 //===----------------------------------------------------------------------===//
-// Copyright © 2025-2026 Apple Inc. and the container project authors.
+// Copyright © 2026 Apple Inc. and the container project authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,10 +14,16 @@
 // limitations under the License.
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
-extension [any Codable] {
-    func jsonArray() throws -> String {
-        "[\(try self.map { String(decoding: try JSONEncoder().encode($0), as: UTF8.self) }.joined(separator: ","))]"
-    }
+/// A type that can be rendered as a table row or quiet-mode output.
+///
+/// Conformers provide the column headers, row values, and a primary identifier
+/// for quiet mode. JSON encoding is handled separately by each command using
+/// its own data model.
+protocol ListDisplayable {
+    /// Column headers for table output (e.g., `["ID", "IMAGE", "STATE"]`).
+    static var tableHeader: [String] { get }
+    /// The values for each column, matching the order of ``tableHeader``.
+    var tableRow: [String] { get }
+    /// The primary identifier shown in `--quiet` mode (typically ID or name).
+    var quietValue: String { get }
 }

--- a/Sources/ContainerCommands/ListFormat.swift
+++ b/Sources/ContainerCommands/ListFormat.swift
@@ -1,0 +1,22 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ArgumentParser
+
+public enum ListFormat: String, CaseIterable, ExpressibleByArgument, Sendable {
+    case json
+    case table
+}

--- a/Sources/ContainerCommands/Network/NetworkInspect.swift
+++ b/Sources/ContainerCommands/Network/NetworkInspect.swift
@@ -34,12 +34,12 @@ extension Application {
         public init() {}
 
         public func run() async throws {
-            let objects: [any Codable] = try await ClientNetwork.list().filter {
+            let items = try await ClientNetwork.list().filter {
                 networks.contains($0.id)
             }.map {
                 PrintableNetwork($0)
             }
-            print(try objects.jsonArray())
+            try printJSON(items)
         }
     }
 }

--- a/Sources/ContainerCommands/Network/NetworkList.swift
+++ b/Sources/ContainerCommands/Network/NetworkList.swift
@@ -41,54 +41,36 @@ extension Application {
 
         public func run() async throws {
             let networks = try await ClientNetwork.list()
-            try printNetworks(networks: networks, format: format)
-        }
+            let items = networks.map { PrintableNetwork($0) }
 
-        private func createHeader() -> [[String]] {
-            [["NETWORK", "STATE", "SUBNET"]]
-        }
-
-        func printNetworks(networks: [NetworkState], format: ListFormat) throws {
             if format == .json {
-                let printables = networks.map {
-                    PrintableNetwork($0)
-                }
-                let data = try JSONEncoder().encode(printables)
-                print(String(decoding: data, as: UTF8.self))
-
+                try printJSON(items)
                 return
             }
 
-            if self.quiet {
-                networks.forEach {
-                    print($0.id)
-                }
-                return
-            }
-
-            var rows = createHeader()
-            for network in networks {
-                rows.append(network.asRow)
-            }
-
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
+            printList(items, quiet: quiet)
         }
     }
 }
 
-extension NetworkState {
-    var asRow: [String] {
-        switch self {
-        case .created(_):
-            return [self.id, self.state, "none"]
-        case .running(_, let status):
+extension PrintableNetwork: ListDisplayable {
+    static var tableHeader: [String] {
+        ["NETWORK", "STATE", "SUBNET"]
+    }
+
+    var tableRow: [String] {
+        if let status {
             return [self.id, self.state, status.ipv4Subnet.description]
         }
+        return [self.id, self.state, "none"]
+    }
+
+    var quietValue: String {
+        self.id
     }
 }
 
-public struct PrintableNetwork: Codable {
+public struct PrintableNetwork: Codable, Sendable {
     let id: String
     let state: String
     let config: NetworkConfiguration

--- a/Sources/ContainerCommands/PrintList.swift
+++ b/Sources/ContainerCommands/PrintList.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// Prints an `Encodable` value as JSON to stdout.
+func printJSON<T: Encodable>(_ value: T, pretty: Bool = false) throws {
+    let encoder = JSONEncoder()
+    if pretty {
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    }
+    let data = try encoder.encode(value)
+    print(String(decoding: data, as: UTF8.self))
+}
+
+/// Prints a list of displayable items as either a table or quiet-mode identifiers.
+///
+/// JSON output is not handled here — each command encodes its own data model
+/// via ``printJSON(_:)`` before reaching this function.
+func printList<T: ListDisplayable>(_ items: [T], quiet: Bool) {
+    if quiet {
+        for item in items {
+            print(item.quietValue)
+        }
+    } else {
+        var rows: [[String]] = [T.tableHeader]
+        for item in items {
+            rows.append(item.tableRow)
+        }
+        let formatter = TableOutput(rows: rows)
+        print(formatter.format())
+    }
+}

--- a/Sources/ContainerCommands/Registry/RegistryList.swift
+++ b/Sources/ContainerCommands/Registry/RegistryList.swift
@@ -29,7 +29,7 @@ extension Application {
         @Option(name: .long, help: "Format of the output")
         var format: ListFormat = .table
 
-        @Flag(name: .shortAndLong, help: "Only output the registry name")
+        @Flag(name: .shortAndLong, help: "Only output the registry hostname")
         var quiet = false
 
         public init() {}
@@ -43,44 +43,37 @@ extension Application {
             let registryInfos = try keychain.list()
             let registries = registryInfos.map { RegistryResource(from: $0) }
 
-            try printRegistries(registries: registries, format: format)
-        }
-
-        private func createHeader() -> [[String]] {
-            [["HOSTNAME", "USERNAME", "MODIFIED", "CREATED"]]
-        }
-
-        private func printRegistries(registries: [RegistryResource], format: ListFormat) throws {
             if format == .json {
-                let data = try JSONEncoder().encode(registries)
-                print(String(decoding: data, as: UTF8.self))
+                try printJSON(registries)
                 return
             }
 
-            if self.quiet {
-                registries.forEach {
-                    print($0.name)
-                }
-                return
-            }
-
-            var rows = createHeader()
-            for registry in registries {
-                rows.append(registry.asRow)
-            }
-
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
+            printList(registries.map { PrintableRegistry($0) }, quiet: quiet)
         }
     }
 }
-extension RegistryResource {
-    fileprivate var asRow: [String] {
+
+private struct PrintableRegistry: ListDisplayable {
+    let registry: RegistryResource
+
+    init(_ registry: RegistryResource) {
+        self.registry = registry
+    }
+
+    static var tableHeader: [String] {
+        ["HOSTNAME", "USERNAME", "MODIFIED", "CREATED"]
+    }
+
+    var tableRow: [String] {
         [
-            self.name,
-            self.username,
-            self.modificationDate.ISO8601Format(),
-            self.creationDate.ISO8601Format(),
+            registry.name,
+            registry.username,
+            registry.modificationDate.ISO8601Format(),
+            registry.creationDate.ISO8601Format(),
         ]
+    }
+
+    var quietValue: String {
+        registry.name
     }
 }

--- a/Sources/ContainerCommands/System/DNS/DNSList.swift
+++ b/Sources/ContainerCommands/System/DNS/DNSList.swift
@@ -38,38 +38,35 @@ extension Application {
         public init() {}
 
         public func run() async throws {
-            let resolver: HostDNSResolver = HostDNSResolver()
+            let resolver = HostDNSResolver()
             let domains = resolver.listDomains()
-            try printDomains(domains: domains, format: format)
-        }
 
-        private func createHeader() -> [[String]] {
-            [["DOMAIN"]]
-        }
-
-        func printDomains(domains: [String], format: ListFormat) throws {
             if format == .json {
-                let data = try JSONEncoder().encode(domains)
-                print(String(decoding: data, as: UTF8.self))
-
+                try printJSON(domains)
                 return
             }
 
-            if self.quiet {
-                domains.forEach { domain in
-                    print(domain)
-                }
-                return
-            }
-
-            var rows = createHeader()
-            for domain in domains {
-                rows.append([domain])
-            }
-
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
+            printList(domains.map { PrintableDomain($0) }, quiet: quiet)
         }
+    }
+}
 
+private struct PrintableDomain: ListDisplayable {
+    let domain: String
+
+    init(_ domain: String) {
+        self.domain = domain
+    }
+
+    static var tableHeader: [String] {
+        ["DOMAIN"]
+    }
+
+    var tableRow: [String] {
+        [domain]
+    }
+
+    var quietValue: String {
+        domain
     }
 }

--- a/Sources/ContainerCommands/System/Property/PropertyList.swift
+++ b/Sources/ContainerCommands/System/Property/PropertyList.swift
@@ -40,41 +40,40 @@ extension Application {
 
         public func run() async throws {
             let vals = DefaultsStore.allValues()
-            try printValues(vals, format: format)
-        }
 
-        private func createHeader() -> [[String]] {
-            [["ID", "TYPE", "VALUE", "DESCRIPTION"]]
-        }
-
-        private func printValues(_ vals: [DefaultsStoreValue], format: ListFormat) throws {
             if format == .json {
-                let data = try JSONEncoder().encode(vals)
-                print(String(decoding: data, as: UTF8.self))
+                try printJSON(vals)
                 return
             }
 
-            if self.quiet {
-                vals.forEach {
-                    print($0.id)
-                }
-                return
-            }
-
-            var rows = createHeader()
-            for property in vals {
-                rows.append(property.asRow)
-            }
-
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
+            printList(vals.map { PrintableProperty($0) }, quiet: quiet)
         }
     }
 }
 
-extension DefaultsStoreValue {
-    var asRow: [String] {
-        [id, String(describing: type), value?.description.elided(to: 40) ?? "*undefined*", description]
+private struct PrintableProperty: ListDisplayable {
+    let id: String
+    let typeName: String
+    let valueDescription: String
+    let description: String
+
+    init(_ value: DefaultsStoreValue) {
+        self.id = value.id
+        self.typeName = String(describing: value.type)
+        self.valueDescription = value.value?.description.elided(to: 40) ?? "*undefined*"
+        self.description = value.description
+    }
+
+    static var tableHeader: [String] {
+        ["ID", "TYPE", "VALUE", "DESCRIPTION"]
+    }
+
+    var tableRow: [String] {
+        [id, typeName, valueDescription, description]
+    }
+
+    var quietValue: String {
+        id
     }
 }
 
@@ -86,7 +85,7 @@ extension String {
         }
 
         if maxCount < ellipsis.count {
-            return ellipsis
+            return String(ellipsis.prefix(maxCount))
         }
 
         let prefixCount = maxCount - ellipsis.count

--- a/Sources/ContainerCommands/System/SystemDF.swift
+++ b/Sources/ContainerCommands/System/SystemDF.swift
@@ -16,7 +16,6 @@
 
 import ArgumentParser
 import ContainerAPIClient
-import ContainerizationError
 import Foundation
 
 extension Application {
@@ -38,16 +37,7 @@ extension Application {
             let stats = try await ClientDiskUsage.get()
 
             if format == .json {
-                let encoder = JSONEncoder()
-                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-                let data = try encoder.encode(stats)
-                guard let jsonString = String(data: data, encoding: .utf8) else {
-                    throw ContainerizationError(
-                        .internalError,
-                        message: "failed to encode JSON output"
-                    )
-                }
-                print(jsonString)
+                try printJSON(stats, pretty: true)
                 return
             }
 

--- a/Sources/ContainerCommands/System/SystemStatus.swift
+++ b/Sources/ContainerCommands/System/SystemStatus.swift
@@ -64,8 +64,7 @@ extension Application {
                         apiServerBuild: "",
                         apiServerAppName: ""
                     )
-                    let data = try JSONEncoder().encode(status)
-                    print(String(decoding: data, as: UTF8.self))
+                    try printJSON(status)
                 } else {
                     print("apiserver is not running and not registered with launchd")
                 }
@@ -87,8 +86,7 @@ extension Application {
                         apiServerBuild: systemHealth.apiServerBuild,
                         apiServerAppName: systemHealth.apiServerAppName
                     )
-                    let data = try JSONEncoder().encode(status)
-                    print(String(decoding: data, as: UTF8.self))
+                    try printJSON(status)
                 } else {
                     let rows: [[String]] = [
                         ["FIELD", "VALUE"],
@@ -116,8 +114,7 @@ extension Application {
                         apiServerBuild: "",
                         apiServerAppName: ""
                     )
-                    let data = try JSONEncoder().encode(status)
-                    print(String(decoding: data, as: UTF8.self))
+                    try printJSON(status)
                 } else {
                     print("apiserver is not running")
                 }

--- a/Sources/ContainerCommands/System/SystemVersion.swift
+++ b/Sources/ContainerCommands/System/SystemVersion.swift
@@ -75,8 +75,7 @@ extension Application {
         }
 
         private func printVersionJSON(versions: [VersionInfo]) throws {
-            let data = try JSONEncoder().encode(versions)
-            print(String(data: data, encoding: .utf8) ?? "[]")
+            try printJSON(versions)
         }
     }
 

--- a/Sources/ContainerCommands/TableOutput.swift
+++ b/Sources/ContainerCommands/TableOutput.swift
@@ -16,11 +16,11 @@
 
 import Foundation
 
-public struct TableOutput {
+struct TableOutput {
     private let rows: [[String]]
     private let spacing: Int
 
-    public init(
+    init(
         rows: [[String]],
         spacing: Int = 2
     ) {
@@ -28,7 +28,7 @@ public struct TableOutput {
         self.spacing = spacing
     }
 
-    public func format() -> String {
+    func format() -> String {
         var output = ""
         let maxLengths = self.maxLength()
 

--- a/Sources/ContainerCommands/Volume/VolumeInspect.swift
+++ b/Sources/ContainerCommands/Volume/VolumeInspect.swift
@@ -45,7 +45,6 @@ extension Application.VolumeCommand {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
             encoder.dateEncodingStrategy = .iso8601
-
             let data = try encoder.encode(volumes)
             print(String(decoding: data, as: UTF8.self))
         }

--- a/Sources/ContainerCommands/Volume/VolumeList.swift
+++ b/Sources/ContainerCommands/Volume/VolumeList.swift
@@ -29,7 +29,7 @@ extension Application.VolumeCommand {
         )
 
         @Option(name: .long, help: "Format of the output")
-        var format: Application.ListFormat = .table
+        var format: ListFormat = .table
 
         @Flag(name: .shortAndLong, help: "Only output the volume name")
         var quiet: Bool = false
@@ -41,52 +41,45 @@ extension Application.VolumeCommand {
 
         public func run() async throws {
             let volumes = try await ClientVolume.list()
-            try printVolumes(volumes: volumes, format: format)
-        }
 
-        private func createHeader() -> [[String]] {
-            [["NAME", "TYPE", "DRIVER", "OPTIONS"]]
-        }
-
-        func printVolumes(volumes: [Volume], format: Application.ListFormat) throws {
             if format == .json {
-                let data = try JSONEncoder().encode(volumes)
-                print(String(decoding: data, as: UTF8.self))
+                try printJSON(volumes)
                 return
             }
 
-            if quiet {
-                volumes.forEach {
-                    print($0.name)
-                }
-                return
-            }
-
-            // Sort volumes by creation time (newest first)
-            let sortedVolumes = volumes.sorted { v1, v2 in
-                v1.createdAt > v2.createdAt
-            }
-
-            var rows = createHeader()
-            for volume in sortedVolumes {
-                rows.append(volume.asRow)
-            }
-
-            let formatter = TableOutput(rows: rows)
-            print(formatter.format())
+            // Sort by creation time (newest first) for table display only,
+            // matching the original behavior where JSON and quiet emit unsorted.
+            let items = quiet ? volumes : volumes.sorted { $0.createdAt > $1.createdAt }
+            printList(items.map { PrintableVolume($0) }, quiet: quiet)
         }
     }
 }
 
-extension Volume {
-    var asRow: [String] {
-        let volumeType = self.isAnonymous ? "anonymous" : "named"
-        let optionsString = options.isEmpty ? "" : options.map { "\($0.key)=\($0.value)" }.joined(separator: ",")
-        return [
-            self.name,
-            volumeType,
-            self.driver,
-            optionsString,
-        ]
+private struct PrintableVolume: ListDisplayable {
+    let name: String
+    let volumeType: String
+    let driver: String
+    let optionsString: String
+
+    init(_ volume: Volume) {
+        self.name = volume.name
+        self.volumeType = volume.isAnonymous ? "anonymous" : "named"
+        self.driver = volume.driver
+        self.optionsString =
+            volume.options.isEmpty
+            ? ""
+            : volume.options.sorted(by: { $0.key < $1.key }).map { "\($0.key)=\($0.value)" }.joined(separator: ",")
+    }
+
+    static var tableHeader: [String] {
+        ["NAME", "TYPE", "DRIVER", "OPTIONS"]
+    }
+
+    var tableRow: [String] {
+        [name, volumeType, driver, optionsString]
+    }
+
+    var quietValue: String {
+        name
     }
 }

--- a/Tests/ContainerCommandsTests/ListFormattingTests.swift
+++ b/Tests/ContainerCommandsTests/ListFormattingTests.swift
@@ -1,0 +1,258 @@
+//===----------------------------------------------------------------------===//
+// Copyright © 2026 Apple Inc. and the container project authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//===----------------------------------------------------------------------===//
+
+import ContainerResource
+import Foundation
+import Testing
+
+@testable import ContainerCommands
+
+// MARK: - Test ListDisplayable conformer
+
+private struct TestItem: ListDisplayable, Codable {
+    let id: String
+    let name: String
+
+    static var tableHeader: [String] { ["ID", "NAME"] }
+    var tableRow: [String] { [id, name] }
+    var quietValue: String { id }
+}
+
+// MARK: - TableOutput tests
+
+struct TableOutputTests {
+    @Test
+    func emptyRowsProducesEmptyString() {
+        let table = TableOutput(rows: [])
+        #expect(table.format() == "")
+    }
+
+    @Test
+    func headerOnlyProducesHeaderRow() {
+        let table = TableOutput(rows: [["ID", "NAME"]])
+        #expect(table.format() == "ID  NAME")
+    }
+
+    @Test
+    func columnsPaddedToMaxWidth() {
+        let rows = [
+            ["ID", "NAME"],
+            ["1", "short"],
+            ["2", "a longer name"],
+        ]
+        let table = TableOutput(rows: rows)
+        let output = table.format()
+        let lines = output.split(separator: "\n")
+        #expect(lines.count == 3)
+
+        // "ID" column should be padded to width of "ID" (2) + spacing (2) = 4
+        #expect(lines[0].hasPrefix("ID  "))
+        #expect(lines[1].hasPrefix("1   "))
+        #expect(lines[2].hasPrefix("2   "))
+    }
+
+    @Test
+    func customSpacing() {
+        let rows = [["A", "B"], ["1", "2"]]
+        let table = TableOutput(rows: rows, spacing: 4)
+        let output = table.format()
+        #expect(output.contains("A    B"))
+    }
+
+    @Test
+    func lastColumnNotPadded() {
+        let rows = [["A", "B"], ["1", "2"]]
+        let table = TableOutput(rows: rows)
+        let lines = table.format().split(separator: "\n")
+        for line in lines {
+            #expect(!line.hasSuffix(" "))
+        }
+    }
+
+    @Test
+    func singleColumnNoPadding() {
+        let rows = [["DOMAIN"], ["example.com"], ["test.local"]]
+        let table = TableOutput(rows: rows)
+        let output = table.format()
+        #expect(output == "DOMAIN\nexample.com\ntest.local")
+    }
+
+    @Test
+    func rowCountMatchesInput() {
+        let rows = [["H1", "H2"], ["a", "b"], ["c", "d"], ["e", "f"]]
+        let table = TableOutput(rows: rows)
+        let lines = table.format().split(separator: "\n")
+        #expect(lines.count == 4)
+    }
+}
+
+// MARK: - printJSON tests
+
+struct PrintJSONTests {
+    @Test
+    func compactModeProducesValidJSON() throws {
+        let items = [TestItem(id: "a", name: "b")]
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(items)
+        let decoded = try JSONDecoder().decode([TestItem].self, from: data)
+        #expect(decoded.count == 1)
+        #expect(decoded[0].id == "a")
+        #expect(decoded[0].name == "b")
+    }
+
+    @Test
+    func compactModeIsSingleLine() throws {
+        let items = [TestItem(id: "a", name: "b"), TestItem(id: "c", name: "d")]
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(items)
+        let output = String(decoding: data, as: UTF8.self)
+        #expect(!output.contains("\n"))
+    }
+
+    @Test
+    func prettyModeIsMultiLine() throws {
+        let items = [TestItem(id: "a", name: "b")]
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(items)
+        let output = String(decoding: data, as: UTF8.self)
+        #expect(output.contains("\n"))
+    }
+
+    @Test
+    func prettyModeHasSortedKeys() throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(["z": 1, "a": 2])
+        let output = String(decoding: data, as: UTF8.self)
+        let aIndex = output.range(of: "\"a\"")!.lowerBound
+        let zIndex = output.range(of: "\"z\"")!.lowerBound
+        #expect(aIndex < zIndex)
+    }
+
+    @Test
+    func arrayEncodingMatchesManualJoin() throws {
+        // Verify that JSONEncoder().encode(array) produces the same result as
+        // encoding each element and joining (the old jsonArray() approach).
+        let items = [TestItem(id: "x", name: "y"), TestItem(id: "a", name: "b")]
+        let encoder = JSONEncoder()
+
+        // Whole-array encoding (new approach via printJSON)
+        let wholeData = try encoder.encode(items)
+        let wholeOutput = String(decoding: wholeData, as: UTF8.self)
+
+        // Per-element encoding (old jsonArray approach)
+        let perElement = try items.map { String(decoding: try encoder.encode($0), as: UTF8.self) }
+        let joinedOutput = "[\(perElement.joined(separator: ","))]"
+
+        // Both should decode to the same structure
+        let decoded1 = try JSONDecoder().decode([TestItem].self, from: wholeOutput.data(using: .utf8)!)
+        let decoded2 = try JSONDecoder().decode([TestItem].self, from: joinedOutput.data(using: .utf8)!)
+        #expect(decoded1.count == decoded2.count)
+        #expect(decoded1[0].id == decoded2[0].id)
+        #expect(decoded1[1].id == decoded2[1].id)
+    }
+}
+
+// MARK: - ListDisplayable contract tests
+
+struct ListDisplayableContractTests {
+    @Test
+    func testItemTableRowMatchesHeaderCount() {
+        let item = TestItem(id: "1", name: "test")
+        #expect(TestItem.tableHeader.count == item.tableRow.count)
+    }
+
+    @Test
+    func quietValueIsNonEmpty() {
+        let item = TestItem(id: "abc", name: "test")
+        #expect(!item.quietValue.isEmpty)
+    }
+}
+
+// MARK: - PrintableContainer conformance tests
+
+struct PrintableContainerDisplayTests {
+    @Test
+    func tableHeaderHasNineColumns() {
+        #expect(PrintableContainer.tableHeader.count == 9)
+        #expect(PrintableContainer.tableHeader[0] == "ID")
+        #expect(PrintableContainer.tableHeader[1] == "IMAGE")
+        #expect(PrintableContainer.tableHeader[2] == "OS")
+        #expect(PrintableContainer.tableHeader[3] == "ARCH")
+        #expect(PrintableContainer.tableHeader[4] == "STATE")
+        #expect(PrintableContainer.tableHeader[5] == "ADDR")
+        #expect(PrintableContainer.tableHeader[6] == "CPUS")
+        #expect(PrintableContainer.tableHeader[7] == "MEMORY")
+        #expect(PrintableContainer.tableHeader[8] == "STARTED")
+    }
+}
+
+// MARK: - PrintableNetwork conformance tests
+
+struct PrintableNetworkDisplayTests {
+    @Test
+    func tableHeaderHasThreeColumns() {
+        #expect(PrintableNetwork.tableHeader.count == 3)
+        #expect(PrintableNetwork.tableHeader[0] == "NETWORK")
+        #expect(PrintableNetwork.tableHeader[1] == "STATE")
+        #expect(PrintableNetwork.tableHeader[2] == "SUBNET")
+    }
+}
+
+// MARK: - ListFormat tests
+
+struct ListFormatTests {
+    @Test
+    func hasJsonAndTableCases() {
+        let cases = ListFormat.allCases
+        #expect(cases.count == 2)
+        #expect(cases.contains(.json))
+        #expect(cases.contains(.table))
+    }
+
+    @Test
+    func rawValuesMatchExpected() {
+        #expect(ListFormat.json.rawValue == "json")
+        #expect(ListFormat.table.rawValue == "table")
+    }
+}
+
+// MARK: - String.elided tests
+
+struct StringElidedTests {
+    @Test
+    func shortStringUnchanged() {
+        #expect("hello".elided(to: 10) == "hello")
+    }
+
+    @Test
+    func exactLengthUnchanged() {
+        #expect("hello".elided(to: 5) == "hello")
+    }
+
+    @Test
+    func longStringTruncatedWithEllipsis() {
+        #expect("hello world".elided(to: 8) == "hello...")
+    }
+
+    @Test
+    func maxCountLessThanEllipsis() {
+        #expect("hello".elided(to: 2) == "..")
+        #expect("hello".elided(to: 1) == ".")
+        #expect("hello".elided(to: 0) == "")
+    }
+}


### PR DESCRIPTION
This PR consolidates the duplicated list formatting logic across all CLI list commands into shared infrastructure.

Every list command independently implemented the same if-json/if-quiet/else-table rendering pattern. This extracts that into a ListDisplayable protocol (table contract), printList() (table/quiet rendering), and printJSON() (all JSON encoding across the module).

JSON encoding is deliberately separated from the display protocol -- each command encodes its own raw data model for JSON, while display types only handle table/quiet. Each command keeps its own --format and --quiet flags with domain-specific help text rather than a generic option group.

Also moves TableOutput to ContainerCommands, deletes Codable+JSON.swift, migrates all remaining inline JSONEncoder usage to printJSON, and adds unit tests for the formatting infrastructure.